### PR TITLE
🚧 0.4.1 Bug Fix Changes

### DIFF
--- a/Carter Games/Notion Database To Unity/Code/Editor/Editors/Inspectors/NotionDataAssetEditor.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Editors/Inspectors/NotionDataAssetEditor.cs
@@ -46,13 +46,17 @@ namespace CarterGames.Standalone.NotionData.Editor
             
             RenderNotionSettings();
             
-            serializedObject.ApplyModifiedProperties();
-            serializedObject.Update();
-            
             EditorGUILayout.Space(1.5f);
             GeneralUtilEditor.DrawHorizontalGUILine();
 
-            DrawPropertiesExcluding(serializedObject, "sortProperties", "filters");
+            EditorGUI.BeginDisabledGroup(true);
+            EditorGUILayout.PropertyField(serializedObject.Fp("m_Script"));
+            EditorGUI.EndDisabledGroup();
+
+            DrawPropertiesExcluding(serializedObject, "sortProperties", "filters", "m_Script");
+            
+            serializedObject.ApplyModifiedProperties();
+            serializedObject.Update();
         }
         
 

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Search/SearchProviderFilterType.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Search/SearchProviderFilterType.cs
@@ -38,7 +38,7 @@ namespace CarterGames.Standalone.NotionData.Editor
 		public override List<SearchGroup<NotionFilterOption>> GetEntriesToDisplay()
 		{
 			var list = new List<SearchGroup<NotionFilterOption>>();
-			var options = AssemblyHelper.GetClassesOfType<NotionFilterOption>(false).Where(t => !ToExclude.Contains(t));
+			var options = AssemblyHelper.GetClassesOfType<NotionFilterOption>(false).Where(t => !ToExclude.Contains(t) && t.EditorTypeName != "Group");
 			var items = new List<SearchItem<NotionFilterOption>>();
 			
 			foreach (var entry in options)

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorMultiSelect.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorMultiSelect.cs
@@ -59,76 +59,92 @@ namespace CarterGames.Standalone.NotionData.Editor
 				EditorGUILayout.PropertyField(property.Fpr("option").Fpr("propertyName"));
 				GUILayout.Space(1f);
 
-				EditorGUILayout.BeginHorizontal();
-				property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
-					(int) (NotionFilerMultiSelectComparison) EditorGUILayout.EnumPopup(
-						(NotionFilerMultiSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
-				GUILayout.Space(1f);
-
-				list = JsonUtility.FromJson<NotionFilterMultiSelectList>(property.Fpr("option").Fpr("value").stringValue);
-
-				if (list != null)
-				{
-					EditorGUILayout.BeginVertical();
-
-					if (list.List.Count <= 0)
-					{
-						GUI.backgroundColor = Color.green;
-						if (GUILayout.Button("+ Add option"))
-						{
-							list.List.Add(string.Empty);
-							property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
-							property.serializedObject.ApplyModifiedProperties();
-							property.serializedObject.Update();
-						}
-						GUI.backgroundColor = Color.white;
-					}
-					else
-					{
-						for (var i = 0; i < list.List.Count; i++)
-						{
-							EditorGUI.BeginChangeCheck();
-
-							EditorGUILayout.BeginHorizontal();
-
-							list.List[i] = EditorGUILayout.TextField(GUIContent.none, list.List[i]);
-
-							GUI.backgroundColor = Color.red;
-							if (GUILayout.Button("-",GUILayout.Width(22.5f)))
-							{
-								list.List.RemoveAt(i);
-								property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
-								property.serializedObject.ApplyModifiedProperties();
-								property.serializedObject.Update();
-								break;
-							}
-							
-							GUI.backgroundColor = Color.white;
-
-							EditorGUILayout.EndHorizontal();
-
-							if (EditorGUI.EndChangeCheck())
-							{
-								property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
-								property.serializedObject.ApplyModifiedProperties();
-								property.serializedObject.Update();
-							}
-						}
-						
-						GUI.backgroundColor = Color.green;
-						if (GUILayout.Button("+ Add option"))
-						{
-							list.List.Add(string.Empty);
-							property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
-							property.serializedObject.ApplyModifiedProperties();
-							property.serializedObject.Update();
-						}
-						GUI.backgroundColor = Color.white;
-					}
-
-					EditorGUILayout.EndVertical();
-				}
 				
+				EditorGUILayout.BeginHorizontal();
+				
+				if (property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 2 ||
+				    property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 3)
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilerMultiSelectComparison) EditorGUILayout.EnumPopup(
+							(NotionFilerMultiSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue);
+				}
+				else
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilerMultiSelectComparison) EditorGUILayout.EnumPopup(
+							(NotionFilerMultiSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex")
+								.intValue, GUILayout.Width(147.5f));
+					GUILayout.Space(1f);
+
+					list = JsonUtility.FromJson<NotionFilterMultiSelectList>(property.Fpr("option").Fpr("value")
+						.stringValue);
+
+					if (list != null)
+					{
+						EditorGUILayout.BeginVertical();
+
+						if (list.List.Count <= 0)
+						{
+							GUI.backgroundColor = Color.green;
+							if (GUILayout.Button("+ Add option"))
+							{
+								list.List.Add(string.Empty);
+								property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
+								property.serializedObject.ApplyModifiedProperties();
+								property.serializedObject.Update();
+							}
+
+							GUI.backgroundColor = Color.white;
+						}
+						else
+						{
+							for (var i = 0; i < list.List.Count; i++)
+							{
+								EditorGUI.BeginChangeCheck();
+
+								EditorGUILayout.BeginHorizontal();
+
+								list.List[i] = EditorGUILayout.TextField(GUIContent.none, list.List[i]);
+
+								GUI.backgroundColor = Color.red;
+								if (GUILayout.Button("-", GUILayout.Width(22.5f)))
+								{
+									list.List.RemoveAt(i);
+									property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
+									property.serializedObject.ApplyModifiedProperties();
+									property.serializedObject.Update();
+									break;
+								}
+
+								GUI.backgroundColor = Color.white;
+
+								EditorGUILayout.EndHorizontal();
+
+								if (EditorGUI.EndChangeCheck())
+								{
+									property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
+									property.serializedObject.ApplyModifiedProperties();
+									property.serializedObject.Update();
+								}
+							}
+
+							GUI.backgroundColor = Color.green;
+							if (GUILayout.Button("+ Add option"))
+							{
+								list.List.Add(string.Empty);
+								property.Fpr("option").Fpr("value").stringValue = JsonUtility.ToJson(list);
+								property.serializedObject.ApplyModifiedProperties();
+								property.serializedObject.Update();
+							}
+
+							GUI.backgroundColor = Color.white;
+						}
+
+						EditorGUILayout.EndVertical();
+					}
+				}
+
 				EditorGUILayout.EndHorizontal();
 			}
 			

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorRichText.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorRichText.cs
@@ -57,11 +57,23 @@ namespace CarterGames.Standalone.NotionData.Editor
 				GUILayout.Space(1f);
 				
 				EditorGUILayout.BeginHorizontal();
-				property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
-					(int) (NotionFilterRichTextComparison) EditorGUILayout.EnumPopup(
-						(NotionFilterRichTextComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
-				GUILayout.Space(1f);
-				EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+
+				if (property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 5 ||
+				    property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 6)
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilterRichTextComparison) EditorGUILayout.EnumPopup(
+							(NotionFilterRichTextComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue);
+				}
+				else
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilterRichTextComparison) EditorGUILayout.EnumPopup(
+							(NotionFilterRichTextComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
+					GUILayout.Space(1f);
+					EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+				}
+				
 				EditorGUILayout.EndHorizontal();
 			}
 			

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorSelect.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorSelect.cs
@@ -57,11 +57,23 @@ namespace CarterGames.Standalone.NotionData.Editor
 				GUILayout.Space(1f);
 				
 				EditorGUILayout.BeginHorizontal();
-				property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
-					(int) (NotionFilerSelectComparison) EditorGUILayout.EnumPopup(
-						(NotionFilerSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
-				GUILayout.Space(1f);
-				EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+				
+				if (property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 2 ||
+				    property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 3)
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilerSelectComparison) EditorGUILayout.EnumPopup(
+							(NotionFilerSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue);
+				}
+				else
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilerSelectComparison) EditorGUILayout.EnumPopup(
+							(NotionFilerSelectComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
+					GUILayout.Space(1f);
+					EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+				}
+				
 				EditorGUILayout.EndHorizontal();
 			}
 			

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorStatus.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/Filters/Type Specific/FilterEditorStatus.cs
@@ -57,11 +57,23 @@ namespace CarterGames.Standalone.NotionData.Editor
 				GUILayout.Space(1f);
 				
 				EditorGUILayout.BeginHorizontal();
-				property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
-					(int) (NotionFilterStatusComparison) EditorGUILayout.EnumPopup(
-						(NotionFilterStatusComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
-				GUILayout.Space(1f);
-				EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+				
+				if (property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 2 ||
+				    property.Fpr("option").Fpr("comparisonEnumIndex").intValue == 3)
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilterStatusComparison) EditorGUILayout.EnumPopup(
+							(NotionFilterStatusComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue);
+				}
+				else
+				{
+					property.Fpr("option").Fpr("comparisonEnumIndex").intValue =
+						(int) (NotionFilterStatusComparison) EditorGUILayout.EnumPopup(
+							(NotionFilterStatusComparison) property.Fpr("option").Fpr("comparisonEnumIndex").intValue, GUILayout.Width(147.5f));
+					GUILayout.Space(1f);
+					EditorGUILayout.PropertyField(property.Fpr("option").Fpr("value"), GUIContent.none);
+				}
+
 				EditorGUILayout.EndHorizontal();
 			}
 			

--- a/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/NotionApiRequestHandler.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Notion/Notion Api/NotionApiRequestHandler.cs
@@ -161,7 +161,10 @@ namespace CarterGames.Standalone.NotionData.Editor
                 
                 if (filters != null)
                 {
-                    body["filter"] = filters.ToFilterJson();
+                    if (filters.TotalFilters > 0)
+                    {
+                        body["filter"] = filters.ToFilterJson();
+                    }
                 }
 
                 request = UnityWebRequest.Put(url, body.ToString());

--- a/Carter Games/Notion Database To Unity/Code/Editor/Supporting Backend/AssetInfo.cs
+++ b/Carter Games/Notion Database To Unity/Code/Editor/Supporting Backend/AssetInfo.cs
@@ -31,7 +31,7 @@ namespace CarterGames.Standalone.NotionData.Editor
         /// <summary>
         /// The version number of the asset.
         /// </summary>
-        public static string VersionNumber => "0.4.0";
+        public static string VersionNumber => "0.4.1";
         
         
         /// <summary>
@@ -40,6 +40,6 @@ namespace CarterGames.Standalone.NotionData.Editor
         /// <remarks>
         /// Format is Y/M/D.
         /// </remarks>
-        public static string ReleaseDate => "2024/12/19";
+        public static string ReleaseDate => "2025/01/18";
     }
 }

--- a/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Multi-Select/NotionFilterMultiSelect.cs
+++ b/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Multi-Select/NotionFilterMultiSelect.cs
@@ -65,7 +65,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 				data["property"] = propertyName;
 			}
 
-			if (Comparison != NotionFilerMultiSelectComparison.IsEmpty ||
+			if (Comparison != NotionFilerMultiSelectComparison.IsEmpty &&
 			    Comparison != NotionFilerMultiSelectComparison.IsNotEmpty)
 			{
 				data["multi_select"][FilterStringLookup[Comparison]] = JsonUtility.ToJson(value);

--- a/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/NotionFilterContainer.cs
+++ b/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/NotionFilterContainer.cs
@@ -47,6 +47,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 					foreach (var entry in group.Value.FilterOptions)
 					{
 						if (entry.TypeName == "Group") continue;
+						if (string.IsNullOrWhiteSpace(entry.TypeName)) continue;
 						total++;
 					}
 				}
@@ -54,7 +55,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 				return total;
 			}
 		}
-		
+
 
 		public JSONObject ToFilterJson()
 		{

--- a/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Rich Text/NotionFilterRichText.cs
+++ b/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Rich Text/NotionFilterRichText.cs
@@ -68,7 +68,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 				data["property"] = propertyName;
 			}
 			
-			if (Comparison != NotionFilterRichTextComparison.IsEmpty ||
+			if (Comparison != NotionFilterRichTextComparison.IsEmpty &&
 			    Comparison != NotionFilterRichTextComparison.IsNotEmpty)
 			{
 				data["rich_text"][FilterStringLookup[Comparison]] = value.ToString();

--- a/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Select/NotionFilterSelect.cs
+++ b/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Select/NotionFilterSelect.cs
@@ -63,7 +63,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 				data["property"] = propertyName;
 			}
 
-			if (Comparison != NotionFilerSelectComparison.IsEmpty ||
+			if (Comparison != NotionFilerSelectComparison.IsEmpty &&
 			    Comparison != NotionFilerSelectComparison.IsNotEmpty)
 			{
 				data["select"][FilterStringLookup[Comparison]] = value.ToString();

--- a/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Status/NotionFilterStatus.cs
+++ b/Carter Games/Notion Database To Unity/Code/Runtime/Notion/Filters/Status/NotionFilterStatus.cs
@@ -63,7 +63,7 @@ namespace CarterGames.Standalone.NotionData.Filters
 				data["property"] = propertyName;
 			}
 			
-			if (Comparison != NotionFilterStatusComparison.IsEmpty ||
+			if (Comparison != NotionFilterStatusComparison.IsEmpty &&
 			    Comparison != NotionFilterStatusComparison.IsNotEmpty)
 			{
 				data["status"][FilterStringLookup[Comparison]] = value.ToString();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "games.carter.standalone.notiondata",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "displayName": "Notion Data (Standalone)",
   "description": "A system to import Notion databases into a Unity scriptable object for use in Unity projects. This is a standalone version of the system in the Cart library of the same name.",
   "unity": "2020.3",


### PR DESCRIPTION
- Fixed filtering issue when empty or not empty used as a comparison type.
- Fixed a soft lock where adding a group filter type would just break things (option removed as you don't need it).
- Updated GUI for empty or not empty to hide the params field as it is not used.
- Added extra validation on filters being applied to the download process.
- Minor GUI update to Notion Data Assets to disable teh GUI around the script field as you'd normally see in inspectors.
- Updated data & package info.